### PR TITLE
fix: use relative file path instead of absolute path in open browser URL

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -290,6 +290,7 @@ impl LanguageServer for Backend {
 
         if let Some((_, service)) = self.get_workspace_for_file(&file_path).await {
             let port = *service.port.lock().await;
+            let relative_path = file_path.strip_prefix(&*service.root).unwrap_or(&file_path);
             let action = CodeActionOrCommand::CodeAction(CodeAction {
                 title: format!("Open in Browser({})", port),
                 kind: Some(CodeActionKind::EMPTY),
@@ -298,7 +299,7 @@ impl LanguageServer for Backend {
                     command: "openProjectWeb".to_string(),
                     arguments: Some(vec![
                         Value::from(service.root.to_str().unwrap_or_default().to_string()),
-                        Value::from(file_path.to_str().unwrap_or_default().to_string()),
+                        Value::from(relative_path.to_str().unwrap_or_default().to_string()),
                     ]),
                 }),
                 edit: None,


### PR DESCRIPTION
The CodeAction 'Open in Browser' was passing the absolute file path to the URL, resulting in URLs like:
  http://127.0.0.1:57391//Users/.../index.html
Now it correctly uses the relative path from the workspace root:
  http://127.0.0.1:57391/index.html
Fix in lsp.rs:code_action() by using strip_prefix() to obtain the relative path before passing it to the openProjectWeb command.